### PR TITLE
Refactor ExternalLink: type safety, error handling, docs (NFR-7) (#121)

### DIFF
--- a/mobile/components/ExternalLink.tsx
+++ b/mobile/components/ExternalLink.tsx
@@ -3,23 +3,47 @@ import * as WebBrowser from 'expo-web-browser';
 import React from 'react';
 import { Platform } from 'react-native';
 
-export function ExternalLink(
-  props: Omit<React.ComponentProps<typeof Link>, 'href'> & { href: string }
-) {
+/** Props for ExternalLink. Extends expo-router Link props with a required string href. */
+export type ExternalLinkProps = Omit<
+  React.ComponentProps<typeof Link>,
+  'href'
+> & {
+  /** URL to open. On native, opens in the in-app browser; on web, behaves as a normal link. */
+  href: string;
+  /** Optional callback when opening the browser fails (native only). */
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Renders a link that opens in the in-app browser on native (iOS/Android) and as a normal
+ * external link on web. Use for documentation, privacy policy, or any external URL.
+ *
+ * @param props - Link props with required `href` (string). Optional `onError` for native open failures.
+ */
+export function ExternalLink(props: ExternalLinkProps) {
+  const { href, onError, ...rest } = props;
+
+  const handlePress = React.useCallback(
+    async (e: { preventDefault?: () => void }) => {
+      if (Platform.OS !== 'web') {
+        e.preventDefault?.();
+        try {
+          await WebBrowser.openBrowserAsync(href);
+        } catch (error) {
+          onError?.(error);
+          // Do not re-throw: avoids crashing when caller does not provide onError
+        }
+      }
+    },
+    [href, onError]
+  );
+
   return (
     <Link
       target="_blank"
-      {...props}
-      // @ts-expect-error: External URLs are not typed.
-      href={props.href}
-      onPress={(e) => {
-        if (Platform.OS !== 'web') {
-          // Prevent the default behavior of linking to the default browser on native.
-          e.preventDefault();
-          // Open the link in an in-app browser.
-          WebBrowser.openBrowserAsync(props.href as string);
-        }
-      }}
+      {...rest}
+      href={href as React.ComponentProps<typeof Link>['href']}
+      onPress={handlePress}
     />
   );
 }


### PR DESCRIPTION
### 🛡️ VIBE Report

1. **Target Selected:** `mobile/components/ExternalLink.tsx` (ExternalLink). It’s low-risk because it’s a single, isolated UI component with a clear contract (props in, link/open behavior out). It doesn’t touch auth, routing, or core app logic, and the only current caller is `EditScreenInfo`, so behavior is easy to verify.

2. **The Verification Event:** The AI suggested re-throwing the error in the `catch` block after calling `onError` so that callers could handle failures. I changed this so we **do not re-throw** when the caller does not provide `onError`.  
   - **AI-style suggestion:** “Re-throw so callers can handle or so the error is visible in dev.”  
   - **Final implementation:** `onError?.(error)` only; no `throw error`. Existing call sites (e.g. `EditScreenInfo`) don’t pass `onError`, so re-throwing would have introduced crashes when `openBrowserAsync` fails (e.g. invalid URL, user cancels, or OS blocks the browser). The refactor adds optional error handling without changing default behavior.

3. **Trust Boundary Established:** The refactor improves stability by: (a) removing `@ts-expect-error` and using a single, justified type assertion plus an explicit `ExternalLinkProps` type so the component is type-safe and documented; (b) wrapping `openBrowserAsync` in try/catch so native open failures don’t bubble as unhandled rejections; (c) adding JSDoc so future changes are guided by a clear contract. The human decision not to re-throw when `onError` is absent is the explicit trust boundary: AI proposed “always re-throw,” human enforced “only surface errors when the caller opts in.”

4. **Evidence of Execution:** Screenshot of the app running in the iPhone 16 Pro simulator (Tab One). The refactored `ExternalLink` renders correctly — the blue link “Tap here if your app doesn’t automatically update after making changes” is visible and tappable; tapping it opens the Expo docs in the in-app browser. Confirms the component still works after the type-safety, error-handling, and JSDoc refactor.

| Tab One – ExternalLink visible | After tap – Expo docs in-app browser |
|-------------------------------|--------------------------------------|
| <img width="320" alt="Screenshot 2026-02-24 at 10 47 24 AM" src="https://github.com/user-attachments/assets/d65b232a-4f31-47a5-a413-e725c1282931" /> | <img width="320" alt="Screenshot 2026-02-24 at 10 47 53 AM" src="https://github.com/user-attachments/assets/4cf0018f-8331-493a-8185-b7625768538c" /> |
