### PR TITLE
Refactor: Introduce RobotServiceClient abstraction for robot status handling

### DIFF
--- a/web-dashboard/src/lib/robotServiceClient.ts
+++ b/web-dashboard/src/lib/robotServiceClient.ts
@@ -1,0 +1,103 @@
+import { apiFetch } from "./api";
+import type { RobotState, RobotStatus } from "./robotTypes";
+
+interface RobotStatusDto {
+  id: string;
+  robot_name: string;
+  status: RobotState;
+  current_location: string;
+  battery_level: number;
+  current_task?:
+    | {
+        task_id: string;
+        task_type: string;
+        destination: string;
+      }
+    | null;
+  last_heartbeat: string;
+}
+
+interface Envelope<T> {
+  success: boolean;
+  data: T;
+  error?: unknown;
+}
+
+export interface RobotServiceClient {
+  /**
+   * Overall status view.
+   * Wraps GET /api/v1/robot/status, which may return a single object or an array.
+   */
+  getAllStatuses(): Promise<RobotStatus[]>;
+
+  /**
+   * Status for a specific robot.
+   * Wraps GET /api/v1/robot/status/{robot_id}.
+   */
+  getStatus(robotId: string): Promise<RobotStatus>;
+
+  /**
+   * Optional polling-based subscription for all robot statuses.
+   * Implementation uses getAllStatuses() under the hood.
+   */
+  subscribeAllStatuses?(onUpdate: (statuses: RobotStatus[]) => void): () => void;
+}
+
+function mapStatusDto(dto: RobotStatusDto): RobotStatus {
+  return {
+    state: dto.status,
+    batteryPercent: Math.round(dto.battery_level * 100),
+    locationLabel: dto.current_location,
+    currentTaskSummary: dto.current_task?.destination ?? undefined,
+    lastHeartbeat: dto.last_heartbeat,
+  };
+}
+
+function normalizeStatuses(data: RobotStatusDto | RobotStatusDto[]): RobotStatus[] {
+  const arr = Array.isArray(data) ? data : [data];
+  return arr.map(mapStatusDto);
+}
+
+export function createRobotServiceClient(): RobotServiceClient {
+  const getAllStatuses: RobotServiceClient["getAllStatuses"] = async () => {
+    const res = await apiFetch("/api/v1/robot/status");
+    if (!res.ok) {
+      throw new Error(`Failed to fetch robot statuses (${res.status})`);
+    }
+    const json = (await res.json()) as Envelope<RobotStatusDto | RobotStatusDto[]>;
+    if (!json.success || !json.data) {
+      throw new Error("Robot status response missing data");
+    }
+    return normalizeStatuses(json.data);
+  };
+
+  const getStatus: RobotServiceClient["getStatus"] = async (robotId) => {
+    const res = await apiFetch(`/api/v1/robot/status/${encodeURIComponent(robotId)}`);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch robot status for ${robotId} (${res.status})`);
+    }
+    const json = (await res.json()) as Envelope<RobotStatusDto>;
+    if (!json.success || !json.data) {
+      throw new Error("Robot status response missing data");
+    }
+    return mapStatusDto(json.data);
+  };
+
+  const subscribeAllStatuses: RobotServiceClient["subscribeAllStatuses"] = (onUpdate) => {
+    const poll = async () => {
+      try {
+        const statuses = await getAllStatuses();
+        onUpdate(statuses);
+      } catch {
+        // Optional: route errors to a central error handler or toast.
+      }
+    };
+
+    void poll();
+    const id = window.setInterval(poll, 5000);
+    return () => window.clearInterval(id);
+  };
+
+  return { getAllStatuses, getStatus, subscribeAllStatuses };
+}
+

--- a/web-dashboard/src/lib/robotStateUi.ts
+++ b/web-dashboard/src/lib/robotStateUi.ts
@@ -1,0 +1,33 @@
+import type { RobotState } from "./robotTypes";
+
+export function getRobotStateLabel(state: RobotState): string {
+  switch (state) {
+    case "IDLE":
+      return "Idle";
+    case "NAVIGATING":
+      return "Navigating";
+    case "BUSY":
+      return "Active";
+    case "MAINTENANCE":
+      return "Maintenance";
+    case "ERROR":
+    default:
+      return "Error";
+  }
+}
+
+export function getRobotStateBadgeColor(state: RobotState): string {
+  switch (state) {
+    case "IDLE":
+      return "bg-muted text-muted-foreground";
+    case "NAVIGATING":
+    case "BUSY":
+      return "bg-success text-success-foreground";
+    case "MAINTENANCE":
+      return "bg-warning text-warning-foreground";
+    case "ERROR":
+    default:
+      return "bg-destructive text-destructive-foreground";
+  }
+}
+

--- a/web-dashboard/src/lib/robotTypes.ts
+++ b/web-dashboard/src/lib/robotTypes.ts
@@ -1,0 +1,10 @@
+export type RobotState = "IDLE" | "NAVIGATING" | "BUSY" | "ERROR" | "MAINTENANCE";
+
+export interface RobotStatus {
+  state: RobotState;
+  batteryPercent: number;
+  locationLabel: string;
+  currentTaskSummary?: string;
+  lastHeartbeat: string;
+}
+

--- a/web-dashboard/src/lib/useRobotStatus.ts
+++ b/web-dashboard/src/lib/useRobotStatus.ts
@@ -1,0 +1,58 @@
+import { useEffect, useMemo, useState } from "react";
+import type { RobotStatus } from "./robotTypes";
+import type { RobotServiceClient } from "./robotServiceClient";
+import { createRobotServiceClient } from "./robotServiceClient";
+
+interface UseRobotStatusResult {
+  statuses: RobotStatus[] | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Hook to consume robot status for the dashboard.
+ *
+ * - By default, creates a RobotServiceClient bound to the real API via apiFetch.
+ * - Tests or storybook can inject a mock RobotServiceClient via clientOverride.
+ */
+export function useRobotStatus(clientOverride?: RobotServiceClient): UseRobotStatusResult {
+  const client = useMemo(
+    () => clientOverride ?? createRobotServiceClient(),
+    [clientOverride]
+  );
+
+  const [statuses, setStatuses] = useState<RobotStatus[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    const unsubscribe = client.subscribeAllStatuses?.((next) => {
+      setStatuses(next);
+      setLoading(false);
+    });
+
+    if (!unsubscribe) {
+      client
+        .getAllStatuses()
+        .then((next) => {
+          setStatuses(next);
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err : new Error("Failed to load robot status"));
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
+  }, [client]);
+
+  return { statuses, loading, error };
+}
+


### PR DESCRIPTION
### Refactor Rationale

This refactor introduces a **RobotServiceClient** interface and supporting hook (useRobotStatus) to formalize the data boundary between the web dashboard UI and the Backend Robot Service API.

Previously, the dashboard only exposed a generic apiFetch utility and did not yet implement a dedicated robot service layer. Without a clear abstraction, future robot-related UI (Dashboard, Maintenance, Map screens) would likely fetch /api/v1/robot/* endpoints ad hoc inside components. 
This risks:

- Tight coupling between UI and transport logic
- Duplicated mapping of backend DTOs to frontend state
- Inconsistent robot state across screens
- Reduced testability and inability to support mock data cleanly

This refactor applies the following software engineering principles:

**1. Separation of Concerns**
Robot data acquisition (REST polling and future WebSocket updates) is encapsulated inside RobotServiceClient. UI components are now responsible only for rendering state.

**2. Dependency Inversion**
Screens and hooks depend on the RobotServiceClient interface rather than directly on fetch or specific endpoints. This allows multiple implementations (API-backed or mock-backed) without changing UI code.

**3. Single Responsibility**
- apiFetch → handles authentication + token refresh
- RobotServiceClient → handles robot-specific API contracts
- useRobotStatus → manages synchronization between service and React state
- Screens → render data only

**4. Alignment with System Design**
The implementation strictly respects the documented architecture:
- Robot posts status to backend Robot Service.
- Dashboard reads status from /api/v1/robot/status.
- Backend remains the single source of truth.
- No direct robot–dashboard communication is introduced.

The service layer leaves room to replace polling with WebSocket events (as defined in the System Design real-time section) without modifying UI components.

### What Changed
**Added**

- robotTypes.ts – frontend domain models aligned with backend Robot Service contract.
- robotServiceClient.ts – defines RobotServiceClient interface and API-backed implementation.
- useRobotStatus.ts – React hook built on the service abstraction.

**Architectural Improvement**

- Introduced a typed DTO mapping layer from backend response envelope → frontend RobotStatus.
- Centralized all /api/v1/robot/status logic into one module.
- Prepared the system for a future MockRobotServiceClient implementation to support offline UI development.

### AI Usage Summary

Cursor (AI-native IDE) was used to assist with architectural analysis and initial scaffolding.

**Prompt Used**
"Analyze how robot status is currently fetched and propose a refactor introducing a RobotServiceClient interface for the web dashboard. Make sure your solution is in accordance with the system design, robot implementation, and frontend implementation docs."

**AI Contributions**
- Identified that robot status is conceptually provided by /api/v1/robot/status, but not yet implemented in the current dashboard.
- Proposed introduction of a typed service layer between apiFetch and UI components.
- Generated initial RobotServiceClient interface structure.
- Generated DTO-to-domain mapping function.
- Drafted initial polling-based subscribeStatus implementation.

**Human Modifications**
- Adjusted endpoint handling to correctly support both:
- GET /api/v1/robot/status
- GET /api/v1/robot/status/{robot_id}
- Refined enum alignment to match backend Robot Service definitions.
- Improved polling implementation to avoid this binding risks.
- Refactored client instantiation to prevent global singleton side effects.
- Ensured strict TypeScript typing and error handling aligned with existing apiFetch behavior.
- Verified compliance with System Design and Backend–Robot Protocol documentation.
- Verification (VIBE – Verify No Regression)

### Manual verification steps:

Start development server:

- npm run dev
- Authenticate via existing /auth/login flow.
- Confirm dashboard renders successfully:

<img width="1431" height="737" alt="image" src="https://github.com/user-attachments/assets/d321c7ff-8a7c-4c8e-b9da-32d903393997" />

Confirm no changes to:

- [ ] Authentication flow
- [ ] Token refresh behavior
- [ ] Existing navigation
- [ ] Non-robot API calls


This refactor moves the dashboard from a prototype-ready state (generic fetch utility only) toward a production-ready layered architecture:

API Client → RobotServiceClient → Hook → Screens

It establishes a clean boundary that will allow:

- Future WebSocket integration without UI changes.
- Introduction of MockRobotServiceClient for offline testing.
- Centralized enforcement of backend contract consistency.
