### PR TITLE
Lab 3 VIBE refactor: centralize auth routing decisions

### DIFF
--- a/web-dashboard/src/layouts/ProtectedRoute.tsx
+++ b/web-dashboard/src/layouts/ProtectedRoute.tsx
@@ -1,11 +1,11 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { ROUTES } from "../lib/routes";
-import { tokenStorage } from "../lib/tokenStorage";
+import { isAuthenticated } from "../lib/authSession";
 
 export function ProtectedRoute() {
-  return tokenStorage.isAuthenticated() ? <Outlet /> : <Navigate to={ROUTES.LOGIN} replace />;
+  return isAuthenticated() ? <Outlet /> : <Navigate to={ROUTES.LOGIN} replace />;
 }
 
 export function PublicOnlyRoute() {
-  return tokenStorage.isAuthenticated() ? <Navigate to={ROUTES.DASHBOARD} replace /> : <Outlet />;
+  return isAuthenticated() ? <Navigate to={ROUTES.DASHBOARD} replace /> : <Outlet />;
 }

--- a/web-dashboard/src/lib/authSession.ts
+++ b/web-dashboard/src/lib/authSession.ts
@@ -1,0 +1,11 @@
+import { ROUTES } from "./routes";
+import { tokenStorage } from "./tokenStorage";
+
+export function isAuthenticated(): boolean {
+  return tokenStorage.isAuthenticated();
+}
+
+export function getRootRedirectPath(): (typeof ROUTES)[keyof typeof ROUTES] {
+  return isAuthenticated() ? ROUTES.DASHBOARD : ROUTES.LOGIN;
+}
+

--- a/web-dashboard/src/routes/AppRouter.tsx
+++ b/web-dashboard/src/routes/AppRouter.tsx
@@ -2,7 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import { ProtectedRoute, PublicOnlyRoute } from "../layouts/ProtectedRoute";
 import TopBarLayout from "../layouts/TopBarLayout";
 import { ROUTES } from "../lib/routes";
-import { tokenStorage } from "../lib/tokenStorage";
+import { getRootRedirectPath } from "../lib/authSession";
 import AccountSettingsScreen from "../screens/AccountSettingsScreen";
 import CatalogScreen from "../screens/CatalogScreen";
 import Dashboard from "../screens/Dashboard";
@@ -15,7 +15,7 @@ import ForgotPasswordScreen from "../screens/ForgotPasswordScreen";
 import ResetPasswordScreen from "../screens/ResetPasswordScreen";
 import SetupAccountScreen from "../screens/SetupAccountScreen";
 
-const RootRedirect = () => <Navigate to={tokenStorage.isAuthenticated() ? ROUTES.DASHBOARD : ROUTES.LOGIN} replace />;
+const RootRedirect = () => <Navigate to={getRootRedirectPath()} replace />;
 
 export default function AppRouter() {
   return (

--- a/web-dashboard/src/vite-env.d.ts
+++ b/web-dashboard/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+

--- a/web-dashboard/tsconfig.app.json
+++ b/web-dashboard/tsconfig.app.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Refactor rationale (architectural debt → principle applied)
**Problem:** Authentication state checks and root redirect decisions were duplicated across routing components (`AppRouter`, `ProtectedRoute`).
- This is minor architectural debt, but it violates **DRY** and blurs **Separation of Concerns** (routing components shouldn’t each re-implement session decision logic).

**Solution:** Extracted the auth-session decision logic into a single module:
- `web-dashboard/src/lib/authSession.ts`
  - `isAuthenticated()`
  - `getRootRedirectPath()`

Routing now consumes a small abstraction instead of repeating branching logic.

## AI usage summary (Cursor / VIBE)
**Prompt (analysis):**
"Find duplicated auth/redirect logic in web-dashboard routing and extract it into a single reusable module without changing runtime behavior."

**Prompt (implementation):**
"Create a small `authSession` helper module and update `ProtectedRoute` + `AppRouter` to use it. Keep the public API minimal."

**Human modifications after AI:**
- Verified the refactor is delegation-only (no behavior change).
- Adjusted build typing to follow Vite convention by adding `src/vite-env.d.ts` and removing `"types": ["vite/client"]` from `tsconfig.app.json` so `tsc -b` succeeds.

## Verification (evidence of no regressions)
Goal: **feature parity** (routing behavior unchanged).
- `cd web-dashboard`
- `npm install`
- `npm run build` ✅

Expected behavior preserved:
- Unauthenticated users are redirected to `/login`
- Authenticated users are redirected to `/dashboard`
- Protected routes still require authentication

## Files changed
- `web-dashboard/src/lib/authSession.ts` (new)
- `web-dashboard/src/routes/AppRouter.tsx`
- `web-dashboard/src/layouts/ProtectedRoute.tsx`
- `web-dashboard/src/vite-env.d.ts` (new)
- `web-dashboard/tsconfig.app.json`